### PR TITLE
PushPayload.php-generateSendno警告

### DIFF
--- a/src/JPush/PushPayload.php
+++ b/src/JPush/PushPayload.php
@@ -351,7 +351,7 @@ class PushPayload {
     }
 
     private function generateSendno() {
-        return rand(100000, 4294967294);
+        return rand(100000, 2147483647);
     }
 
     # new methods


### PR DESCRIPTION
如果未通过options设置sendto参数，generateSendno此方法的rand()会提示警告。Warning: rand() expects parameter 2 to be integer, float given，原参数4294967294超过int范围，改成2147483647即可。